### PR TITLE
fix ParseFromString for empty messages

### DIFF
--- a/cprotobuf/internal.pyx
+++ b/cprotobuf/internal.pyx
@@ -247,7 +247,7 @@ class ProtoEntity(object):
         cdef char *end
         cdef Py_ssize_t size = len(s)
 
-        assert offset < size, "Offset out of bound."
+        assert offset <= size, "Offset out of bound."
         assert count < size-offset, "Count out of bound."
 
         start = buff + offset


### PR DESCRIPTION
Thanks for the package! ParseFromString doesn't work for parsing empty message strings at the moment; this patch should fix it.

Running the following script in the `test` directory triggers the behavior:

```python
import test_pb
t = test_pb.Test()
s = t.SerializeToString()
t.ParseFromString(s)
```